### PR TITLE
feat: Implement response caching for API routes

### DIFF
--- a/app/_components/PopulationChartContainer/PopulationChartContainer.module.css
+++ b/app/_components/PopulationChartContainer/PopulationChartContainer.module.css
@@ -1,8 +1,9 @@
-@keyframes fadeIn {
-  from {
+@keyframes delayDisplay {
+  0%,
+  99% {
     opacity: 0;
   }
-  to {
+  100% {
     opacity: 1;
   }
 }
@@ -16,7 +17,7 @@
   aspect-ratio: 2 / 1;
 }
 
-.wrap {
+.loading {
   position: absolute;
   z-index: 10;
   top: 0;
@@ -28,6 +29,8 @@
 
   width: 100%;
   height: 100%;
+
+  animation: delayDisplay 0.2s;
 
   color: white;
   background-color: rgba(0, 0, 0, 0.4);

--- a/app/_components/PopulationChartContainer/index.tsx
+++ b/app/_components/PopulationChartContainer/index.tsx
@@ -70,7 +70,7 @@ export const PopulationChartContainer = () => {
           </div>
           <div className={styles.chart}>
             {isLoading && (
-              <div className={styles.wrap}>
+              <div className={styles.loading}>
                 <Image src="/reload.svg" alt="Loading" width={48} height={48} />
               </div>
             )}

--- a/app/api/population/route.ts
+++ b/app/api/population/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
+import { getFromResasApi } from '../../_utils/getFromResasApi'
 import { createResponse } from '../../_utils/createResponse'
 import { z } from 'zod'
-import { getFromResasApi } from '@/app/_utils/getFromResasApi'
 
 const prefCodeSchema = z.number()
 
@@ -37,6 +37,14 @@ export async function GET(request: Request) {
   }
 
   return NextResponse.json(
-    createResponse({ status: 'ok', data: populationData })
+    createResponse({ status: 'ok', data: populationData }),
+    {
+      headers: {
+        'Cache-Control': 'max-age=10',
+        'CDN-Cache-Control': 'max-age=60',
+        'Vercel-CDN-Cache-Control':
+          'max-age=604800, stale-while-revalidate=3600',
+      },
+    }
   )
 }

--- a/app/api/population/route.ts
+++ b/app/api/population/route.ts
@@ -40,8 +40,8 @@ export async function GET(request: Request) {
     createResponse({ status: 'ok', data: populationData }),
     {
       headers: {
-        'Cache-Control': 'max-age=10',
-        'CDN-Cache-Control': 'max-age=60',
+        'Cache-Control': 'max-age=180',
+        'CDN-Cache-Control': 'max-age=600',
         'Vercel-CDN-Cache-Control':
           'max-age=604800, stale-while-revalidate=3600',
       },


### PR DESCRIPTION
Next.jsのAPI Routes(app routerでは名前変わってた気がする・・)のレスポンスがめちゃくちゃ遅い！！！！（RESAS APIは30msくらいで応答するのに、API Routesは1sくらいかかる😡）

ので、レスポンスを一定期間キャッシュする。（RESAS APIの内容はそうそう変わることはないので）

stale-while-revalidateを使い鮮度を保ちつつ、クライアントへは基本キャッシュを返す。

結果、サーバーの応答速度が1007ms -> 24msまで改善した！素晴らしい（自画自賛）

9/18 11:00時点のMainブランチ: https://yumemi-frontend-test-828n01z34-avaice.vercel.app/
キャッシュの改善を行なった後のブランチ: https://yumemi-frontend-test-2ndl5mrgz-avaice.vercel.app/

----

**キャッシュが全くない場合(1007ms)**

https://github.com/avaice/yumemi-frontend-test/assets/80768507/cad8b0f9-9015-4791-82c1-e69991e97d1d

**サーバー側でレスポンスをキャッシュしている場合(24ms)**

https://github.com/avaice/yumemi-frontend-test/assets/80768507/ffe29288-c7b2-4ab6-ad38-962298244ee4

**クライアント側でレスポンスをキャッシュしている場合(2ms)**

https://github.com/avaice/yumemi-frontend-test/assets/80768507/168721eb-014e-42d6-8c3c-4f50334d046b

